### PR TITLE
require Locale::Codes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,1 +1,4 @@
 [@Milla]
+
+[Prereqs / RuntimeRequires]
+Locale::Codes = 0


### PR DESCRIPTION
this module needs Locale::Country (part of Locale::Codes) but doesn't explicitly specify it in the build. It seems it is not included by default in newer versions of perl.